### PR TITLE
Update version to v1.1.0-alpha.11

### DIFF
--- a/kanidm.rb
+++ b/kanidm.rb
@@ -1,8 +1,8 @@
 class Kanidm < Formula
   desc "Kanidm CLI"
   homepage "https://github.com/kanidm/kanidm"
-  url "https://github.com/kanidm/kanidm/archive/refs/tags/v1.1.0-alpha.10.tar.gz"
-  sha256 "c709c2073739ae713af51f2062aab61bc5299a594db5074625ee87fa340f4330"
+  url "https://github.com/kanidm/kanidm/archive/refs/tags/v1.1.0-alpha.11.tar.gz"
+  sha256 "78c12b14441c554edce8ff3801bd31878e25c474098d64d4bb4d06165c559027"
   license "Mozilla Public License 2.0"
   head "https://github.com/kanidm/kanidm.git", branch: "master"
 


### PR DESCRIPTION
Tested that this worked:

```
brew install trissylegs/kanidm/kanidm
==> Fetching dependencies for trissylegs/kanidm/kanidm: rust
==> Fetching rust
==> Downloading https://ghcr.io/v2/homebrew/core/rust/manifests/1.67.0
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/rust/blobs/sha256:3bbd58b85e50f6c31c5b82cae21d4383eff1e2d79e61a1f643b0e4aedae6572a
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:3bbd58b85e50f6c31c5b82cae21d4383eff1e2d79e61a1f643b0e4aedae6572a?se=2023-02-0
######################################################################## 100.0%
==> Fetching trissylegs/kanidm/kanidm
==> Downloading https://github.com/kanidm/kanidm/archive/refs/tags/v1.1.0-alpha.11.tar.gz
==> Downloading from https://codeload.github.com/kanidm/kanidm/tar.gz/refs/tags/v1.1.0-alpha.11
  # #=O=#   #                                                                 
==> Installing kanidm from trissylegs/kanidm
==> Installing dependencies for trissylegs/kanidm/kanidm: rust
==> Installing trissylegs/kanidm/kanidm dependency: rust
==> Pouring rust--1.67.0.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/rust/1.67.0: 36,648 files, 891.6MB
==> Installing trissylegs/kanidm/kanidm
==> cargo install --bin kanidm kanidm_tools
🍺  /opt/homebrew/Cellar/kanidm/1.1.0-alpha.11: 7 files, 16.2MB, built in 1 minute 43 seconds
==> Running `brew cleanup kanidm`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/nirya/Library/Caches/Homebrew/kanidm--1.1.0-alpha.10.tar.gz... (4.9MB)
```


```
$ kanidm version  
kanidm 1.1.0-alpha.11 2ced48a
2023-02-03T10:02:23.044961Z DEBUG kanidm: Using 10 worker threads
```

