### PR TITLE
Update version to v1.2.0

### DIFF
--- a/kanidm.rb
+++ b/kanidm.rb
@@ -1,9 +1,9 @@
 class Kanidm < Formula
   desc "Kanidm CLI"
-  version "v1.1.0-rc.16"
+  version "v1.2.0"
   homepage "https://api.github.com/kanidm/kanidm/releases/latest"
   url "https://github.com/kanidm/kanidm/archive/refs/tags/#{version}.tar.gz"
-  sha256 "26e275bf6cf19dba34a2cc0d382c22e3b3c887f15e9fe64a1c011098173a1de9"
+  sha256 "a6dc0578e61d8445f6fb6bb9a0e17dcd5bfd8412b40d26eceafabe3d92f1ac12"
   license "Mozilla Public License 2.0"
   head "https://github.com/kanidm/kanidm.git", branch: "master"
 


### PR DESCRIPTION
Tested and works fine on Apple Silicon
```
$ brew tap jakobzudrell/homebrew-kanidm
==> Tapping jakobzudrell/kanidm
Cloning into '/opt/homebrew/Library/Taps/jakobzudrell/homebrew-kanidm'...
remote: Enumerating objects: 89, done.
remote: Counting objects: 100% (89/89), done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 89 (delta 59), reused 75 (delta 50), pack-reused 0
Receiving objects: 100% (89/89), 19.85 KiB | 3.31 MiB/s, done.
Resolving deltas: 100% (59/59), done.
Tapped 1 formula (20 files, 32.5KB).
$ brew install kanidm
==> Fetching jakobzudrell/kanidm/kanidm
==> Downloading https://github.com/kanidm/kanidm/archive/refs/tags/v1.2.0.tar.gz
Already downloaded: /Users/jakobzudrell/Library/Caches/Homebrew/downloads/616f9af5579e58a88138a00007b8e05f1e36719eff22a44640444293334b9554--kanidm-1.2.0.tar.gz
==> Installing kanidm from jakobzudrell/kanidm
==> cargo install --bin kanidm --path tools/cli --root /opt/homebrew/Cellar/kanidm/v1.2.0
🍺  /opt/homebrew/Cellar/kanidm/v1.2.0: 7 files, 17MB, built in 1 minute 21 seconds
==> Running `brew cleanup kanidm`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```
```
$ kanidm version
kanidm 1.2.0
2024-05-02T10:44:35.919609Z DEBUG kanidm: Using 8 worker threads
```