### PR TITLE
Update to v1.2.3

### DIFF
--- a/kanidm.rb
+++ b/kanidm.rb
@@ -1,9 +1,9 @@
 class Kanidm < Formula
   desc "Kanidm CLI"
-  version "v1.2.0"
+  version "v1.2.3"
   homepage "https://api.github.com/kanidm/kanidm/releases/latest"
   url "https://github.com/kanidm/kanidm/archive/refs/tags/#{version}.tar.gz"
-  sha256 "a6dc0578e61d8445f6fb6bb9a0e17dcd5bfd8412b40d26eceafabe3d92f1ac12"
+  sha256 "afbc0c71485394b0833f21525cc696d421b7ce4636ba1729e35e358c774e8b96"
   license "Mozilla Public License 2.0"
   head "https://github.com/kanidm/kanidm.git", branch: "master"
 


### PR DESCRIPTION
This brings the homebrew tap up to date with the latest release.